### PR TITLE
Update `md ipi` example

### DIFF
--- a/examples/md-ipi/README.md
+++ b/examples/md-ipi/README.md
@@ -29,7 +29,7 @@ i-pi input.xml > i-pi.out &
 sleep 5
 
 # Start LOREM driver
-i-pi-driver -a lorem -u -m lorem \
+i-pi-driver-py -a lorem -u -m lorem \
     -o model_path=${MODEL_PATH},template=start.xyz \
     > driver.out &
 

--- a/examples/md-ipi/input.xml
+++ b/examples/md-ipi/input.xml
@@ -15,7 +15,6 @@
     <trajectory filename='becx'>becx</trajectory>
     <trajectory filename='becy'>becy</trajectory>
     <trajectory filename='becz'>becz</trajectory>
-    <trajectory filename='dip' extra_type='dipole'> extras </trajectory>
     <properties filename='properties.out' verbosity='low' > [ step, time, conserved, kinetic_md, potential, Efield, Eenvelope ] </properties>
   </output>
 

--- a/examples/md-ipi/run.sh
+++ b/examples/md-ipi/run.sh
@@ -21,7 +21,7 @@ echo "i-PI started"
 sleep 5
 
 # Start LOREM driver
-i-pi-driver -a lorem -u -m lorem \
+i-pi-driver-py -a lorem -u -m lorem \
     -o model_path=${MODEL_PATH},template=start.xyz \
     > driver.out &
 echo "LOREM driver started"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,10 @@ addopts = [
     "--cov-report=",
     "--import-mode=append",
 ]
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    "ignore:jax.core.get_opaque_trace_state is deprecated.:DeprecationWarning",
+]
 
 [tool.ruff]
 exclude = ["src/lorem/_version.py"]


### PR DESCRIPTION
Seems like `i-pi-driver` cannot use the copy-pasted lorem driver, but only `i-pi-driver-py` can. Also the model actually doesn't return dipole to i-pi, so I removed the line from the ipi input