### PR TITLE
Fix flaky neighbor-list cache force tests (symmetry-zero forces)

### DIFF
--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -178,6 +178,9 @@ def test_calculator_cell_change_within_skin():
     """
     model = Lorem(cutoff=5.0, num_features=8, num_spherical_features=2, num_radial=4)
     atoms = bulk("Ar") * [2, 2, 2]
+    # Rattle for non-zero forces: on a perfect crystal forces vanish by
+    # symmetry, leaving only float32 noise sensitive to neighbor-list order.
+    atoms.rattle(0.1, seed=42)
 
     calc = Calculator.from_model(model, skin=0.5)
     calc.calculate(atoms)
@@ -258,6 +261,9 @@ def test_calculator_combined_position_and_cell_change():
     """Both position and cell change within skin — correct results."""
     model = Lorem(cutoff=5.0, num_features=8, num_spherical_features=2, num_radial=4)
     atoms = bulk("Ar") * [2, 2, 2]
+    # Rattle for non-zero forces: on a perfect crystal forces vanish by
+    # symmetry, leaving only float32 noise sensitive to neighbor-list order.
+    atoms.rattle(0.1, seed=42)
 
     calc = Calculator.from_model(model, skin=0.5)
     calc.calculate(atoms)


### PR DESCRIPTION
## Problem

`tests (ubuntu-22.04, *)` and `tests (macos-14, 3.14)` have been red on `main`
since the dependency bump in #13/#14, with two failures:

- `test_calculator_cell_change_within_skin`
- `test_calculator_combined_position_and_cell_change`

Both fail on the **forces** assertion (`atol=1e-5`); the energy assertions pass.

## Root cause

Not a bug in the neighbor-list cache — the cache is correct. The two tests
compare cached-reuse vs fresh-rebuild on a **perfect FCC Ar supercell**, where
the true forces are **zero by symmetry**. The ~1e-2 "forces" are pure float32
symmetry-breaking noise.

A cached batch keeps the skin-shell pairs from the *reference* geometry, so it
carries a different number of (zero-contributing, beyond-cutoff) pairs than a
fresh build. Same physics, different array shape → different XLA float32
**reduction order in the backward pass**. The forward pass (energy) stays
**bit-identical** (`|dE| = 0`); only the force noise diverges (~3–6e-4).

This was latent until the dependency bump: with `jax 0.9.1` the forces came out
bit-identical; with `jax 0.10.1` + `ase 3.28` XLA's reduction changed and the
rounding now differs — hence green CI on 2026-03-30, red by 2026-05-26 with no
code change in between. Confirmed it is **not** the long-range Ewald path: the
discrepancy persists with `lr=False`, and a fresh-vs-fresh comparison that only
changes the skin reproduces it.

## Fix

Rattle the structures (`atoms.rattle(0.1, seed=42)`) so the forces are
physically meaningful rather than symmetry-zero noise. With real forces
(~2–8e-2), cached and fresh agree to **~1e-8**, well within the existing
`atol=1e-5`. `needs_update` still correctly returns `False`. The cache logic is
untouched.

## Verification

Full suite via `uvx tox -e tests` (jax 0.10.1 / ase 3.28): **51 passed**
(previously 2 failed, 49 passed). `uvx tox -e lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)