### PR TITLE
Pin grain <0.2.17 to fix examples job on Linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dependencies = [
     "jax-pme @ git+https://github.com/lab-cosmo/jax-pme.git",
     "jaxtyping",
     "marathon-train[grain]",
+    # grain 0.2.17 reads an unparsed absl flag in worker threads on linux
+    # (xprof regression, google/grain c06d4565); pin until fixed upstream.
+    "grain<0.2.17",
     "opsis",
     "optax",
 ]


### PR DESCRIPTION
## Problem

The `examples` CI job fails on Linux with:

```
absl.flags._exceptions.UnparsedFlagAccessError: Trying to access flag
--grain_enable_multiprocess_worker_profiling before flags were parsed.
```

thrown from a grain data-loader prefetch worker while `lorem-train` iterates
the validation dataset.

## Root cause

`grain` **0.2.17** (released 2026-06-01) integrated xprof subprocess trace
collection into PyGrain workers ([google/grain `c06d4565`](https://github.com/google/grain/commit/c06d4565)),
which now reads the absl flag `--grain_enable_multiprocess_worker_profiling`
from worker prefetch threads. `lorem-train` is a plain console entry point
(`lorem.train:main`) that never goes through `absl.app.run()`, so flags are
never parsed and the read raises.

It only bites on **Linux**: the xprof subprocess hooks ship in the Linux wheel
but not macOS, so grain's `is_worker_profiling_supported()` gates the flag read
off locally (macOS CI and local dev are unaffected — which is why this was
green until the unpinned dep drifted to 0.2.17).

This is a fresh upstream regression (0.2.17 is days old, no fixed release yet,
not reported upstream at time of writing). `grain` 0.2.16 (Feb 2026) is the
last good version.

## Fix

Pin `grain<0.2.17` until it's fixed upstream. `grain` enters only via
`marathon-train[grain]`, which has no version bound, so this resolves cleanly
back to 0.2.16. No code workaround (e.g. `flags.FLAGS.mark_as_parsed()`) needed.

## Verification

`uvx tox -e examples` on a freshly resolved env (confirmed it picks
`grain==0.2.16`): all four smoke tests pass — `examples: OK`. The
`UnparsedFlagAccessError` is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)