### PR TITLE
Fix batches_per_epoch overcount in pipeline benchmark

### DIFF
--- a/src/lorem/train.py
+++ b/src/lorem/train.py
@@ -481,7 +481,8 @@ def main():
         median_train_batch_size = int(np.median(real["samples"]))
 
         median_batch_size = median_train_batch_size
-        batches_per_epoch = num_batches
+        # num_batches spans probe_epochs, so divide it out
+        batches_per_epoch = int(num_batches / probe_epochs)
     else:
         pipeline_speed = 0.0
         median_batch_size = median_valid_batch_size


### PR DESCRIPTION
The pipeline benchmark probes `probe_epochs` (= 2) epochs and counts the *total* batches in `num_batches`. `batches_per_epoch` was set to that total, overcounting per-epoch by `probe_epochs` and stretching the LR schedule so it never annealed to `min_learning_rate`. Divide it out.

Closes #10.

_(written by Claude on Marcel's behalf)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)