### PR TITLE
Only advertise BEC capability when the model predicts it

### DIFF
--- a/src/lorem/calculator.py
+++ b/src/lorem/calculator.py
@@ -21,12 +21,8 @@ class Calculator(BaseCalculator):
     def todict(self):
         return self.parameters
 
-    implemented_properties = [
-        "born_effective_charges",
-        "energy",
-        "forces",
-        "stress",
-    ]
+    # default; rebuilt per-instance in __init__ from what the model predicts
+    implemented_properties = ["energy", "forces"]
 
     def __init__(
         self,
@@ -36,6 +32,7 @@ class Calculator(BaseCalculator):
         cutoff,
         atoms=None,
         stress=False,
+        bec=False,
         add_offset=True,
         double_precision=False,
         skin=0.25,
@@ -48,8 +45,12 @@ class Calculator(BaseCalculator):
 
         self._nl_cache = NeighborListCache(skin=skin)
 
-        if not stress:
-            self.implemented_properties = ["born_effective_charges", "energy", "forces"]
+        # only advertise what the model actually produces
+        self.implemented_properties = ["energy", "forces"]
+        if stress:
+            self.implemented_properties.append("stress")
+        if bec:
+            self.implemented_properties.append("born_effective_charges")
 
         predict_fn = lambda params, batch: pred_fn(params, batch, stress=stress)
 
@@ -70,6 +71,7 @@ class Calculator(BaseCalculator):
         if species_weights is None:
             species_weights = {}
             kwargs.setdefault("add_offset", False)
+        kwargs.setdefault("bec", _model_predicts_bec(model))
         return cls(model.predict, species_weights, params, model.cutoff, **kwargs)
 
     @classmethod
@@ -91,6 +93,7 @@ class Calculator(BaseCalculator):
 
         params = read_msgpack(folder / "model/model.msgpack")
 
+        kwargs.setdefault("bec", _model_predicts_bec(model))
         return cls(model.predict, species_to_weight, params, model.cutoff, **kwargs)
 
     def update(self, atoms):
@@ -234,3 +237,9 @@ class Calculator(BaseCalculator):
     def get_potential_energy(self, atoms=None, force_consistent=True):
         # force_consistent is ignored; we are always consistent
         return self.get_property(name="energy", atoms=atoms)
+
+
+def _model_predicts_bec(model):
+    from lorem.models.bec import LoremBEC
+
+    return isinstance(model, LoremBEC)

--- a/src/lorem/ipi.py
+++ b/src/lorem/ipi.py
@@ -17,7 +17,9 @@ class LOREM_driver(ASEDriver):
         self.model_path = model_path
         self.skin = skin
         super().__init__(template, *args, **kwargs)
-        self.capabilities.append("born_effective_charges")
+        # only advertise BEC if the model predicts it
+        if "born_effective_charges" in self.ase_calculator.implemented_properties:
+            self.capabilities.append("born_effective_charges")
 
     def check_parameters(self):
         super().check_parameters()

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -47,6 +47,31 @@ def test_calculator_bec_get_property():
     assert bec.shape == (len(atoms), 3, 3)
 
 
+def test_implemented_properties_non_bec():
+    """A plain Lorem model must not advertise born_effective_charges (issue #4)."""
+    model = Lorem(cutoff=5.0, num_features=8, num_spherical_features=2, num_radial=4)
+    calc = Calculator.from_model(model)
+    assert "born_effective_charges" not in calc.implemented_properties
+    assert "stress" not in calc.implemented_properties
+    assert "energy" in calc.implemented_properties
+    assert "forces" in calc.implemented_properties
+
+
+def test_implemented_properties_bec():
+    """A LoremBEC model advertises born_effective_charges."""
+    model = LoremBEC(cutoff=5.0, num_features=8, num_spherical_features=2, num_radial=4)
+    calc = Calculator.from_model(model)
+    assert "born_effective_charges" in calc.implemented_properties
+
+
+def test_implemented_properties_stress():
+    """The stress flag toggles the stress capability independently of BEC."""
+    model = Lorem(cutoff=5.0, num_features=8, num_spherical_features=2, num_radial=4)
+    calc = Calculator.from_model(model, stress=True)
+    assert "stress" in calc.implemented_properties
+    assert "born_effective_charges" not in calc.implemented_properties
+
+
 def test_calculator_skin_default():
     """Calculator defaults to skin=0.25."""
     model = Lorem(cutoff=5.0, num_features=8, num_spherical_features=2, num_radial=4)


### PR DESCRIPTION
The calculator hardcoded `born_effective_charges` in `implemented_properties` and the i-PI driver always appended it to its capabilities — but only `LoremBEC` emits `apt`/born effective charges. A plain `Lorem` model therefore claimed a property it never computes, which breaks i-PI runs without BEC.

Now BEC is detected at init (`isinstance(model, LoremBEC)`) and `implemented_properties` is built from what the model actually produces (energy/forces always; stress and BEC conditionally). The i-PI driver advertises the BEC capability only when the calculator implements it.

Verified: `uvx tox -e lint` clean, `uvx tox -e tests` 54 passed (3 new).

Closes #4.

_(written by Claude on Marcel's behalf)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)