### PR TITLE
Drop FilterEmpty from the training pipeline

### DIFF
--- a/src/lorem/train.py
+++ b/src/lorem/train.py
@@ -214,7 +214,6 @@ def main():
         DataLoader,
         DataSource,
         FilterAboveNumAtoms,
-        FilterEmpty,
         FilterMixedPBC,
         FilterNoop,
         IndexSampler,
@@ -237,8 +236,6 @@ def main():
     batcher = get_batcher()  # only used for its class methods
 
     # -- setup filters for dataloaders --
-    filter_empty = FilterEmpty()
-
     filters = [FilterNoop()]
     if should_filter_mixedpbc:
         filters.append(FilterMixedPBC())
@@ -295,7 +292,6 @@ def main():
                 operations=[
                     *filters,
                     to_sample,
-                    FilterEmpty(),
                     get_batcher(valid=True),
                 ],
                 worker_count=worker_count_valid,
@@ -308,9 +304,7 @@ def main():
         for i in range(n_valid):
             atoms = source_valid[i]
             if all([f.filter(atoms) for f in filters]):
-                sample = to_sample.map(atoms)
-                if filter_empty.filter(sample):
-                    yield sample
+                yield to_sample.map(atoms)
 
     valid_stats = get_stats(valid_samples(), keys=keys, properties=properties)
 
@@ -337,14 +331,12 @@ def main():
                 RandomRotation(),
                 *filters,
                 to_sample,
-                FilterEmpty(),
                 get_batcher(),
             ]
         else:
             operations = [
                 *filters,
                 to_sample,
-                FilterEmpty(),
                 get_batcher(),
             ]
 
@@ -967,12 +959,10 @@ def main():
             for i in range(len(source)):
                 atoms = source[i]
                 if all([f.filter(atoms) for f in filters]):
-                    sample = to_sample.map(atoms)
-                    if filter_empty.filter(sample):
-                        yield Record(
-                            data=sample,
-                            metadata=RecordMetadata(index=i, record_key=i),
-                        )
+                    yield Record(
+                        data=to_sample.map(atoms),
+                        metadata=RecordMetadata(index=i, record_key=i),
+                    )
 
         batches = [b.data for b in batcher(it())]
         test[name] = (batches, save)


### PR DESCRIPTION
`FilterEmpty` silently dropped any sample whose real-space neighborlist is empty (`len(sr.centers) == 0`). For a long-range model that's wrong — configurations with no short-range neighbours (separated dimers, isolated atoms) are physically meaningful and must be trained on. This removes the filter from all four pipeline sites (train/valid iterators and the two stats generators) plus its import.

**Safety of empty short-range neighborlists** (the concern flagged in the issue):
- The model's short-range message passing is a `segment_sum` over `sr.centers`, so zero edges → zero messages, falling back to per-atom features.
- jax-pme's Ewald computes every real-space term as a masked `segment_sum` over the pair list, and the periodic k-space term uses `atom_to_atom` / `k_grid` independently of the real-space pairs — so a missing short-range list does not break the long-range sum.
- A forward pass on separated dimers and single atoms (pbc and non-pbc) produces finite energy and forces, no crash/NaN. The batcher pads a zero-edge sample to one masked pair.

Verified: `uvx tox -e lint` clean, `uvx tox -e tests` 54 passed.

Closes #12.

> **Note:** this branch is based on top of #20 to avoid a rebase. Until #20 is merged, the diff here also shows the #20 changes; once #20 lands on `main`, this PR will show only the `train.py` change. **Please merge #20 first.**

_(written by Claude on Marcel's behalf)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)