### PR TITLE
Ignore training run outputs (run/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ _version.py
 build/
 dist/
 uv.lock
+
+# training run outputs (train.py defaults workdir to ./run)
+run/


### PR DESCRIPTION
Training writes checkpoints, plots and logs to `./run` (the default `workdir` in `train.py`). Add `run/` to `.gitignore` so those outputs can't be committed by accident.

_(written by Claude on Marcel's behalf)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)