### PR TITLE
NaN in spherical_norm's second-order gradient at exact-zero input

### DIFF
--- a/src/lorem/models/backbone.py
+++ b/src/lorem/models/backbone.py
@@ -2,7 +2,6 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-import functools
 from collections.abc import Sequence
 
 import e3x
@@ -197,24 +196,14 @@ def degree_wise_repeat_last_axis(x, max_degree: int):
     )(x)
 
 
-@functools.partial(jax.custom_jvp, nondiff_argnums=(1,))
+# keeps norm's gradient smooth at x=0; higher-order autodiff works without a custom_jvp
+_SPHERICAL_NORM_EPS = 1e-12
+
+
 def spherical_norm(X, max_degree):
     squared = jax.lax.square(X)
     trace = degree_wise_trace(squared, max_degree)
-    norm = jnp.sqrt(trace)
-    return norm
-
-
-@spherical_norm.defjvp
-def spherical_norm_jvp(max_degree, primals, tangents):
-    (x,) = primals
-    (x_dot,) = tangents
-    primal_out = spherical_norm(x, max_degree)
-
-    x_hat = x / degree_wise_repeat(jnp.where(primal_out > 0, primal_out, 1), max_degree, -1)
-
-    tangent_out = degree_wise_trace(x_dot * x_hat, max_degree)
-    return primal_out, tangent_out
+    return jnp.sqrt(trace + _SPHERICAL_NORM_EPS)
 
 
 def spherical_norm_last_axis(X, max_degree):

--- a/tests/test_backbone.py
+++ b/tests/test_backbone.py
@@ -62,7 +62,7 @@ def test_spherical_norm():
 
 
 def test_spherical_norm_gradient():
-    """Verify the custom JVP is consistent with finite differences."""
+    """Verify the gradient is consistent with finite differences."""
     prev = jax.config.jax_enable_x64
     jax.config.update("jax_enable_x64", True)
     try:
@@ -86,6 +86,24 @@ def test_spherical_norm_gradient():
         np.testing.assert_allclose(grad_custom, grad_fd, atol=1e-5)
     finally:
         jax.config.update("jax_enable_x64", prev)
+
+
+def test_spherical_norm_second_derivative_at_zero():
+    """2nd order gradients of spherical_norm must stay finite at an exact-zero input."""
+
+    max_degree = 2
+    num_lm = (max_degree + 1) ** 2
+    x0 = jnp.zeros((1, num_lm))
+
+    def f(x):
+        return jnp.sum(spherical_norm(x, max_degree))
+
+    def second_grad(x):
+        return jax.grad(lambda x: jnp.sum(jax.grad(f)(x)))(x)
+
+    for fn in (second_grad, jax.jit(second_grad)):
+        g2 = fn(x0)
+        assert bool(jnp.all(jnp.isfinite(g2)))
 
 
 def test_spherical_norm_last_axis():


### PR DESCRIPTION
While working on the charge conditioning, Claude found an issue with second order derivatives of the spherical_norm's at zero.

I am not sure if this is the best solution @sirmarcel but it looks simple and clean.

I also provides the dataset and inputs if we want to dig deeper.

[artifacts.zip](https://github.com/user-attachments/files/30587475/artifacts.zip)


<details>
  <summary>Claude's findings</summary>

x/||x|| (the gradient of a vector norm) is genuinely non-smooth at x=0, so the previous jax.custom_jvp -- which only guarded the forward division against a zero norm -- couldn't give a well-defined *second* derivative there. This produced NaN (under jit specifically) wherever training differentiates through spherical_norm twice, e.g. forces = grad(energy, positions) followed by grad(loss(forces), params).

Replaced the custom_jvp with a smooth epsilon-regularized norm (sqrt(trace + eps)): with no branching left, plain autodiff handles arbitrary differentiation order everywhere, including at x=0, with no special-casing needed.

Found while training LOREM with the Ewald long-range channel enabled on a real (non-toy) dataset with force labels: the LR block's extra spherical-feature norm call operates on values that can be exactly zero for masked/padding atoms, a combination no prior training run had exercised (all lr=False, or lr=True only on toy/no-force smoke tests).

<details>
